### PR TITLE
Help command fix

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -24,10 +24,11 @@ class PWBotHelp(commands.HelpCommand):
             title='All commands',
             colour=Colour.light_blue(),
         )
+
         for command in all_commands:
             embed.add_field(
                 name=self.get_command_signature(command),
-                value=command.brief or self.generate_brief(command.help),
+                value=command.brief or self.generate_brief(command.help) or '*missing*',
                 inline=False
             )
 

--- a/cogs/suggestions.py
+++ b/cogs/suggestions.py
@@ -26,7 +26,7 @@ class Suggestions(commands.Cog):
         except discord.errors.NotFound:
             return
 
-    @commands.command()
+    @commands.command(hidden=True)
     async def dump(self, ctx):
         suggestions = self.bot.get_channel(self.bot.settings.suggestions_channel)
         async for message in suggestions.history(limit=None, after=763599102734106634):


### PR DESCRIPTION
Add a default string for the embed value to prevent this from happening in the future and hide the dump command in the suggestions cog. This bug occurred because there is no docstring or the dump command which caused an error to occur. 